### PR TITLE
Fix icon typing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/src/components/ui/EmptyState.tsx
+++ b/src/components/ui/EmptyState.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { DivideIcon as LucideIcon } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
 
 interface EmptyStateProps {
   icon?: LucideIcon;


### PR DESCRIPTION
## Summary
- use lucide's `LucideIcon` type instead of importing a specific icon
- add a `.gitignore`

## Testing
- `npm run lint` *(fails: `Unexpected any` lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6841a9b7e8d0833394c63896ab21271c