### PR TITLE
Fix extra quote in player empty state button

### DIFF
--- a/src/components/players/PlayersList.tsx
+++ b/src/components/players/PlayersList.tsx
@@ -60,7 +60,7 @@ const PlayersList: React.FC = () => {
             title="No players found"
             description={searchQuery ? "Try a different search term" : "Add your first opponent to get started"}
             action={
-              <button className="btn btn-primary\" onClick={() => setShowForm(true)}>
+              <button className="btn btn-primary" onClick={() => setShowForm(true)}>
                 Add a player
               </button>
             }


### PR DESCRIPTION
## Summary
- fix stray quote in the `PlayersList` empty state button

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6842a87ffb1c8333aa4376553df25878